### PR TITLE
Proposed fix for double-blind mode (Issue #1)

### DIFF
--- a/oopsla2016.sty
+++ b/oopsla2016.sty
@@ -33,10 +33,12 @@
 
 \DeclareOption{1stsubmission}{
   \renewcommand{\authorinfo}[3]{
-    \global\@increment \@authorcount
-    \@withname\gdef {\@authorname\romannumeral\@authorcount}{Please}%
-    \@withname\gdef {\@authoraffil\romannumeral\@authorcount}{anonymize}%
-    \@withname\gdef {\@authoremail\romannumeral\@authorcount}{your paper}
+    \ifnum\@authorcount=0  % only process first call to \authorinfo
+      \global\@increment \@authorcount
+      \@withname\gdef {\@authorname\romannumeral\@authorcount}{Double-blind submission}%
+      \@withname\gdef {\@authoraffil\romannumeral\@authorcount}{}%
+      \@withname\gdef {\@authoremail\romannumeral\@authorcount}{}
+    \fi
   }
   \@setflag \@preprint = \@true
 


### PR DESCRIPTION
I propose to change the option `1stsubmission` so that it causes the author row to contain the text "Double-blind submission", hiding the authors' names. That way the author does not have to add a special `\if` in their code, and the author names will be automatically hidden in the first submission.
